### PR TITLE
Requeue in progress jobs and clean stale lock info on stop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/albrow/jobs v0.4.2
-	github.com/alicebob/miniredis/v2 v2.14.3 // indirect
+	github.com/alicebob/miniredis/v2 v2.14.3
 	github.com/benmanns/goworker v0.1.3
 	github.com/bitly/go-simplejson v0.5.0 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect

--- a/worker_pool_test.go
+++ b/worker_pool_test.go
@@ -154,7 +154,7 @@ func TestWorkersPoolRunSingleThreaded(t *testing.T) {
 	assert.EqualValues(t, 0, listSize(pool, redisKeyJobs(ns, job1)))
 	assert.EqualValues(t, 0, listSize(pool, redisKeyJobsInProgress(ns, wp.workerPoolID, job1)))
 	assert.EqualValues(t, 0, getInt64(pool, redisKeyJobsLock(ns, job1)))
-	assert.EqualValues(t, 0, hgetInt64(pool, redisKeyJobsLockInfo(ns, job1), wp.workerPoolID))
+	assert.False(t, hexists(pool, redisKeyJobsLockInfo(ns, job1), wp.workerPoolID))
 }
 
 func TestWorkerPoolPauseSingleThreadedJobs(t *testing.T) {
@@ -203,7 +203,7 @@ func TestWorkerPoolPauseSingleThreadedJobs(t *testing.T) {
 	assert.EqualValues(t, 0, listSize(pool, redisKeyJobs(ns, job1)))
 	assert.EqualValues(t, 0, listSize(pool, redisKeyJobsInProgress(ns, wp.workerPoolID, job1)))
 	assert.EqualValues(t, 0, getInt64(pool, redisKeyJobsLock(ns, job1)))
-	assert.EqualValues(t, 0, hgetInt64(pool, redisKeyJobsLockInfo(ns, job1), wp.workerPoolID))
+	assert.False(t, hexists(pool, redisKeyJobsLockInfo(ns, job1), wp.workerPoolID))
 }
 
 // Test Helpers


### PR DESCRIPTION
In case there is a failover with a Redis Sentinel cluster with data loss
there can be stale lock information which can cause job processing to be
stuck if the max concurrency limit is reached. Therefore, re-enqueue the
jobs which were in progress and also clean the stale lock info for the
worker pool.

For the cleanup to be thorough, the stop would need to be called on each
worker pool instance.